### PR TITLE
gh-pagesブランチを自動作成するように変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./code/dist
+          force_orphan: true


### PR DESCRIPTION
### プルリクエストの概要

GitHub Actionsのデプロイ用ワークフローに以下の変更を加えました：

- `force_orphan` オプションを追加しました。これにより、デプロイ時に`gh-pages`ブランチが強制的に孤立した状態で作成されるようになります。

### 変更内容

`.github/workflows/deploy.yml` ファイルに以下の1行を追加しました：

```yaml
force_orphan: true
```

### 理由

- 以前の設定では、`gh-pages`ブランチが既存のコミット履歴に依存していました。この変更により、デプロイごとに新しいコミット履歴が作成され、履歴の競合を防ぐことができます。

### テスト

- ワークフローが正常に動作することを確認するため、手動でワークフローをトリガーし、`gh-pages`ブランチが正しく更新されることを確認しました。